### PR TITLE
Add script to fill CSF seg for canal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Installation**
+# Installation
 Pour utiliser le code de segmentation du canal spinal à partir des segmentations de la moelle et du CSF il est nécessaire d'installer les librairies utilisées. la ligne qui permet d'installer ces librairie est incluse dans celles pour cloner le Github.
 Ensuite, il faut cloner le Github à l'aide de la suite de commande suivante : 
 ~~~
@@ -6,7 +6,7 @@ pip install -r requirements.txt
 git clone https://github.com/ivadomed/model-csf-seg.git
 ~~~
 
-**Fonctionnement**
+# Fonctionnement
 À partir de la segmentation de la moelle, le centre de masse est déterminé pour chaque tranche transversale.
 Si il n'y as pas de segmentation du CSF (le CSF n'apparait pas sur l'image), on ne remplace pas l'image.
 Si il n'y as pas de segmentation de la moelle, on met l'image à 0.
@@ -15,7 +15,7 @@ Le code évalue ensuite si l'image est pleine de 1 (région non fermée lors du 
 Si l'image est pleine de 1, on reprend l'image de base et on fait une fermeture.
 Le fait de faire la fermeture sur certaines images ne semble pas causée d'ajout de bruit à l'extérieur du CSF selon ce que j'ai observé.
 
-**Utilisation**
+# Utilisation
 Le code prend en entrée 3 arguments   
 
 -s Le fichier nii.gz de segmentation de la moelle épinière  

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 **Installation**
 Pour utiliser le code de segmentation du canal spinal à partir des segmentations de la moelle et du CSF il est nécessaire d'installer les librairies utilisées. la ligne qui permet d'installer ces librairie est incluse dans celles pour cloner le Github.
 Ensuite, il faut cloner le Github à l'aide de la suite de commande suivante : 
-
-`pip install -r requirements.txt`
-
+~~~
+pip install -r requirements.txt`
+~~~
 
 **Fonctionnement**
 À partir de la segmentation de la moelle, le centre de masse est déterminé pour chaque tranche transversale.

--- a/README.md
+++ b/README.md
@@ -2,18 +2,19 @@
 Pour utiliser le code de segmentation du canal spinal à partir des segmentations de la moelle et du CSF il est nécessaire d'installer les librairies utilisées. la ligne qui permet d'installer ces librairie est incluse dans celles pour cloner le Github.
 Ensuite, il faut cloner le Github à l'aide de la suite de commande suivante : 
 ~~~
-pip install -r requirements.txt
 git clone https://github.com/ivadomed/model-csf-seg.git
+cd model-csg-seg
+pip install -r requirements.txt
 ~~~
 
 # Fonctionnement
 À partir de la segmentation de la moelle, le centre de masse est déterminé pour chaque tranche transversale.
-Si il n'y as pas de segmentation du CSF (le CSF n'apparait pas sur l'image), on ne remplace pas l'image.
-Si il n'y as pas de segmentation de la moelle, on met l'image à 0.
-Si le CSF et la moelle on des segmentations sur la tranche, un floodfill est fait à partir du centre de masse déterminé plus haut.
-Le code évalue ensuite si l'image est pleine de 1 (région non fermée lors du floodfill)
-Si l'image est pleine de 1, on reprend l'image de base et on fait une fermeture.
-Le fait de faire la fermeture sur certaines images ne semble pas causée d'ajout de bruit à l'extérieur du CSF selon ce que j'ai observé.
+- Si il n'y as pas de segmentation du CSF (le CSF n'apparait pas sur l'image), on ne remplace pas l'image.
+- Si il n'y as pas de segmentation de la moelle, on met l'image à 0.
+- Si le CSF et la moelle on des segmentations sur la tranche, un floodfill est fait à partir du centre de masse déterminé plus haut.
+- Le code évalue ensuite si l'image est pleine de 1 (région non fermée lors du floodfill)
+- Si l'image est pleine de 1, on reprend l'image de base et on fait une fermeture.
+- Le fait de faire la fermeture sur certaines images ne semble pas causée d'ajout de bruit à l'extérieur du CSF selon ce que j'ai observé.
 
 # Utilisation
 Le code prend en entrée 3 arguments   

--- a/README.md
+++ b/README.md
@@ -18,10 +18,15 @@ pip install -r requirements.txt
 
 # Utilisation
 Le code prend en entrée 3 arguments   
+* `-i`: Segmentation du CSF (.nii.gz)
 
--s Le fichier nii.gz de segmentation de la moelle épinière  
+* `-s`:  Segmentation de la moelle épinière  (.nii.gz) 
 
--o Le nom que vous souhaiter donner au fichier  
+* `-o` Le nom que vous souhaiter donner au fichier (.nii.gz) 
 
--i Le fichier nii.gz de la segmentation du csf  
+Voici donc un exemple de commande pour utiliser la fonction :
+~~~
+python3 fill-csf.py -i <CSF seg> -s <spinal cord seg> -o <output>
+~~~
+ 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 Pour utiliser le code de segmentation du canal spinal à partir des segmentations de la moelle et du CSF il est nécessaire d'installer les librairies utilisées. la ligne qui permet d'installer ces librairie est incluse dans celles pour cloner le Github.
 Ensuite, il faut cloner le Github à l'aide de la suite de commande suivante : 
 ~~~
-pip install -r requirements.txt`
+pip install -r requirements.txt
+git clone https://github.com/ivadomed/model-csf-seg.git
 ~~~
 
 **Fonctionnement**

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+**Installation**
+Pour utiliser le code de segmentation du canal spinal à partir des segmentations de la moelle et du CSF il est nécessaire d'installer les librairies utilisées. la ligne qui permet d'installer ces librairie est incluse dans celles pour cloner le Github.
+Ensuite, il faut cloner le Github à l'aide de la suite de commande suivante : 
+
+
+**Fonctionnement**
+À partir de la segmentation de la moelle, le centre de masse est déterminé pour chaque tranche transversale.
+Si il n'y as pas de segmentation du CSF (le CSF n'apparait pas sur l'image), on ne remplace pas l'image.
+Si il n'y as pas de segmentation de la moelle, on met l'image à 0.
+Si le CSF et la moelle on des segmentations sur la tranche, un floodfill est fait à partir du centre de masse déterminé plus haut.
+Le code évalue ensuite si l'image est pleine de 1 (région non fermée lors du floodfill)
+Si l'image est pleine de 1, on reprend l'image de base et on fait une fermeture.
+Le fait de faire la fermeture sur certaines images ne semble pas causée d'ajout de bruit à l'extérieur du CSF selon ce que j'ai observé.
+
+**Utilisation**
+Le code prend en entrée 3 arguments   
+
+-s Le fichier nii.gz de segmentation de la moelle épinière  
+
+-o Le nom que vous souhaiter donner au fichier  
+
+-i Le fichier nii.gz de la segmentation du csf  
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 Pour utiliser le code de segmentation du canal spinal à partir des segmentations de la moelle et du CSF il est nécessaire d'installer les librairies utilisées. la ligne qui permet d'installer ces librairie est incluse dans celles pour cloner le Github.
 Ensuite, il faut cloner le Github à l'aide de la suite de commande suivante : 
 
+`pip install -r requirements.txt`
+
 
 **Fonctionnement**
 À partir de la segmentation de la moelle, le centre de masse est déterminé pour chaque tranche transversale.

--- a/fill-csf.py
+++ b/fill-csf.py
@@ -64,7 +64,7 @@ def main() :
             img_fill[:,:,slice] = flood_fill(img_fill[:,:,slice], (cmmoelle[0],cmmoelle[1]), 1)
 
             if np.sum(img_fill[:,:,slice] == 1) == (h*w): #Si ma forme n'est pas fermée je reprend l'image de base et je fais une fermeture
-                        img_fill[:, :, slice] = cv.morphologyEx(img_b[:,:,slice], cv.MORPH_CLOSE,disk(20))
+                        img_fill[:, :, slice] = cv.morphologyEx(img_b[:,:,slice], cv.MORPH_CLOSE,disk(5))
             
         slice = slice+1 #Je passe à la prochaine slice
 

--- a/fill-csf.py
+++ b/fill-csf.py
@@ -9,46 +9,54 @@ from skimage.segmentation import flood_fill
 import scipy as sc
 import numpy as np
 
+def segmentcanal(csfseg,moelleseg) : 
 #Fonction pour sauvegarder fournis par Sandrine
-def save_Nifti1(data, original_image, filename):
-    empty_header = nib.Nifti1Header()
-    image = nib.Nifti1Image(data, original_image.affine, empty_header)
-    nib.save(image, filename)
+    def save_Nifti1(data, original_image, filename):
+        empty_header = nib.Nifti1Header()
+        image = nib.Nifti1Image(data, original_image.affine, empty_header)
+        nib.save(image, filename)
 
-#Je load l'image(pour l'instant j'ai mis le nom du fichier mais il faudra mettre de manière itérative)
-img=nib.load("sub-cmrrb03_T2w_csfseg-manual_RPI_r.nii")
-img_np = img.get_fdata()
+#Je load l'image
+    moelle=nib.load(moelleseg)
+    moelle_np=moelle.get_fdata()
+    img=nib.load(csfseg)
+    img_np = img.get_fdata()
 
 #Je copie l'image pour avoir l'image pour la sauvegarder à la fin
-img_b=img_np.copy()
+    img_b=img_np.copy()
+    moelle_b=moelle_np.copy()
 #Image qui sera remplie (besoin pour éviter les floodfill quand ce n'est pas fermé)
-img_fill=img_b.copy()
+    img_fill=img_b.copy()
 
 #Méthode du floodfill avec le centre de masse
-imagenbr=img_b.shape[2]#Je prend le nombre de coupe transversale
-slice=0
-h,w=img_b[:,:,1].shape
+    imagenbr=img_b.shape[2]#Je prend le nombre de coupe transversale
+    slice=0
+    h,w=img_b[:,:,1].shape
 
-while slice<imagenbr : #J'itère sur les images de coupe
-    seed=(sc.ndimage.center_of_mass(img_b[:,:,slice]))
+    while slice<imagenbr : #J'itère sur les images de coupe
+        cmcsf=(sc.ndimage.center_of_mass(img_b[:,:,slice]))
+        cmmoelle=(sc.ndimage.center_of_mass(moelle_b[:,:,slice]))
     
-    if np.isnan(seed[0]) and np.isnan(seed[1]) : #Si l'image est toute noire on ne change rien
-        img_fill[:,:,slice]=img_b[:,:,slice] 
+        if np.isnan(cmcsf[0]) and np.isnan(cmcsf[1]) : #Si il n'y as pas de segmentation sur le csf on ne change rien
+            img_fill[:,:,slice]=img_b[:,:,slice] 
 
-    else : #Si la segmentation n'est pas nulle dans la slice
-        seed=list(seed)
-        seed[0]=int(seed[0])
-        seed[1]=int(seed[1])
-        if img_fill[:,:,slice][seed[0],seed[1]]==1 : #Si mon centre de masse est sur un pixel qui vaut 1 alors je fait une fermeture
+        else : #Si la segmentation n'est pas nulle dans la slice
 
-            img_fill[:,:,slice]=cv.morphologyEx(img_b[:,:,slice], cv.MORPH_CLOSE,disk(20))
-        else : #Sinon je remplis à partir du centre de masse avec un floodfill
-            img_fill[:,:,slice]=flood_fill(img_fill[:,:,slice],(seed[0],seed[1]),1)
+            if np.isnan(cmmoelle[0]) and np.isnan(cmmoelle[1]) :#Si il n'y as pas de segmentation sur la moelle je ne change rien et je retire la segmentation du csf
+                img_fill[:,:,slice]=0
 
-            if np.sum(img_fill[:,:,slice]==1)==(h*w): #Si ma forme n'est pas fermée je reprend l'image de base et je fais un floodfill
-                img_fill[:,:,slice]=cv.morphologyEx(img_b[:,:,slice], cv.MORPH_CLOSE,disk(20))
+            else :#Si il y as une segmentation de la moelle et du csf je prend le centre de masse de la moelle 
+                cmmoelle=list(cmmoelle)
+                cmmoelle[0]=int(cmmoelle[0])
+                cmmoelle[1]=int(cmmoelle[1])
+                img_fill[:,:,slice]=flood_fill(img_fill[:,:,slice],(cmmoelle[0],cmmoelle[1]),1)
+
+                if np.sum(img_fill[:,:,slice]==1)==(h*w): #Si ma forme n'est pas fermée je reprend l'image de base et je fais une fermeture
+                    img_fill[:,:,slice]=cv.morphologyEx(img_b[:,:,slice], cv.MORPH_CLOSE,disk(20))
             
-    slice=slice+1 #Je passe à la prochaine slice
+        slice=slice+1 #Je passe à la prochaine slice
 
 #Je sauvegarde l'image(Je ne sais pas comment renommer mes images seulement une façon qui ressemble à la votre)
-save_Nifti1(img_fill,img,"sub-cmrrb03_T2w_canal-manual_RPI_r.nii.gz")
+    Nomdecanal=csfseg.replace("csfseg-manual_RPI_r.nii","canalseg-manual_RPI_r.nii.")
+    save_Nifti1(img_fill,img, Nomdecanal)
+segmentcanal("sub-pavia04_T2w_csfseg-manual_RPI_r.nii","sub-pavia04_T2w_seg.nii")

--- a/fill-csf.py
+++ b/fill-csf.py
@@ -1,0 +1,26 @@
+#Authors : William Sirois
+
+#J'importe ce dont j'ai besoin
+import nibabel as nib
+import matplotlib.pyplot as plt
+import cv2
+from skimage.morphology import disk
+
+#Fonction pour sauvegarder fournis par Sandrine
+def save_Nifti1(data, original_image, filename):
+    empty_header = nib.Nifti1Header()
+    image = nib.Nifti1Image(data, original_image.affine, empty_header)
+    nib.save(image, filename)
+
+#Je load l'image(pour l'instant j'ai mis le nom du fichier mais il faudra mettre de manière itérative)
+img=nib.load("sub-cmrrb03_T2w_csfseg-manual_RPI_r.nii")
+img_np = img.get_fdata()
+
+#Je copie l'image pour avoir l'image pour la sauvegarder à la fin
+img_b=img_np.copy()
+
+#Je fais une fermeture avec un disque de 20(juste un essai certainement pas la meilleure valeure)
+img_fill=cv2.morphologyEx(img_b, cv2.MORPH_CLOSE,disk(20))
+
+#Je sauvegarde l'image(Je ne sais pas comment renommer mes images seulement une façon qui ressemble à la votre)
+save_Nifti1(img_fill,img,"sub-cmrrb03_T2w_canal-manual_RPI_r.nii")

--- a/fill-csf.py
+++ b/fill-csf.py
@@ -59,4 +59,3 @@ def segmentcanal(csfseg,moelleseg) :
 #Je sauvegarde l'image(Je ne sais pas comment renommer mes images seulement une façon qui ressemble à la votre)
     Nomdecanal=csfseg.replace("csfseg-manual_RPI_r.nii","canalseg-manual_RPI_r.nii.")
     save_Nifti1(img_fill,img, Nomdecanal)
-segmentcanal("sub-pavia04_T2w_csfseg-manual_RPI_r.nii","sub-pavia04_T2w_seg.nii")

--- a/fill-csf.py
+++ b/fill-csf.py
@@ -3,8 +3,11 @@
 #J'importe ce dont j'ai besoin
 import nibabel as nib
 import matplotlib.pyplot as plt
-import cv2
+import cv2 as cv
 from skimage.morphology import disk
+from skimage.segmentation import flood_fill
+import scipy as sc
+import numpy as np
 
 #Fonction pour sauvegarder fournis par Sandrine
 def save_Nifti1(data, original_image, filename):
@@ -18,9 +21,34 @@ img_np = img.get_fdata()
 
 #Je copie l'image pour avoir l'image pour la sauvegarder à la fin
 img_b=img_np.copy()
+#Image qui sera remplie (besoin pour éviter les floodfill quand ce n'est pas fermé)
+img_fill=img_b.copy()
 
-#Je fais une fermeture avec un disque de 20(juste un essai certainement pas la meilleure valeure)
-img_fill=cv2.morphologyEx(img_b, cv2.MORPH_CLOSE,disk(20))
+#Méthode du floodfill avec le centre de masse
+imagenbr=img_b.shape[2]#Je prend le nombre de coupe transversale
+slice=0
+h,w=img_b[:,:,1].shape
+
+while slice<imagenbr : #J'itère sur les images de coupe
+    seed=(sc.ndimage.center_of_mass(img_b[:,:,slice]))
+    
+    if np.isnan(seed[0]) and np.isnan(seed[1]) : #Si l'image est toute noire on ne change rien
+        img_fill[:,:,slice]=img_b[:,:,slice] 
+
+    else : #Si la segmentation n'est pas nulle dans la slice
+        seed=list(seed)
+        seed[0]=int(seed[0])
+        seed[1]=int(seed[1])
+        if img_fill[:,:,slice][seed[0],seed[1]]==1 : #Si mon centre de masse est sur un pixel qui vaut 1 alors je fait une fermeture
+
+            img_fill[:,:,slice]=cv.morphologyEx(img_b[:,:,slice], cv.MORPH_CLOSE,disk(20))
+        else : #Sinon je remplis à partir du centre de masse avec un floodfill
+            img_fill[:,:,slice]=flood_fill(img_fill[:,:,slice],(seed[0],seed[1]),1)
+
+            if np.sum(img_fill[:,:,slice]==1)==(h*w): #Si ma forme n'est pas fermée je reprend l'image de base et je fais un floodfill
+                img_fill[:,:,slice]=cv.morphologyEx(img_b[:,:,slice], cv.MORPH_CLOSE,disk(20))
+            
+    slice=slice+1 #Je passe à la prochaine slice
 
 #Je sauvegarde l'image(Je ne sais pas comment renommer mes images seulement une façon qui ressemble à la votre)
-save_Nifti1(img_fill,img,"sub-cmrrb03_T2w_canal-manual_RPI_r.nii")
+save_Nifti1(img_fill,img,"sub-cmrrb03_T2w_canal-manual_RPI_r.nii.gz")

--- a/fill-csf.py
+++ b/fill-csf.py
@@ -12,11 +12,11 @@ import argparse
 def get_parser():
     parser = argparse.ArgumentParser(
     description="Close the segmentation of the CSF to get the segmentation of the canal." )
-    parser.add_argument('-i', required = True, type=str,
+    parser.add_argument('-i', dest='CSF_seg', required = True, type=str,
                         help="Input segmentation of the CSF.")
-    parser.add_argument('-o', required = True, type=str,
+    parser.add_argument('-o', dest='Output_name', required = True, type=str,
                         help="Ouput image name.")
-    parser.add_argument('-s', required = True, type=str, 
+    parser.add_argument('-s', dest='Cord_seg', required = True, type=str, 
                         help="Segmentation of the spinal cord ")
 
     return parser
@@ -33,9 +33,9 @@ def main() :
         nib.save(image, filename)
 
 #Je load l'image
-    moelle = nib.load(args.s)
+    moelle = nib.load(args.Cord_seg)
     moelle_np = moelle.get_fdata()
-    img = nib.load(args.i)
+    img = nib.load(args.CSF_seg)
     img_np = img.get_fdata()
 
 #Je copie l'image pour avoir l'original pour la sauvegarder à la fin
@@ -75,8 +75,11 @@ def main() :
         slice = slice+1 #Je passe à la prochaine slice
 
 #Je sauvegarde l'image(Je ne sais pas comment renommer mes images seulement une façon qui ressemble à la votre)
-    save_Nifti1(img_fill, img, args.o)
+    save_Nifti1(img_fill, img, args.Output_name)
 
 
 if __name__ == '__main__':
-    main() 
+    parser = get_parser()
+    args = parser.parse_args()
+    main()
+    print(f'Segmentation realised and saved in {args.Output_name}') 

--- a/fill-csf.py
+++ b/fill-csf.py
@@ -1,15 +1,31 @@
 #Authors : William Sirois
 
+# For usage, type: python fill-csf.py -h or in WSL python3 fill-csf.py -h
 #J'importe ce dont j'ai besoin
 import nibabel as nib
-import matplotlib.pyplot as plt
 import cv2 as cv
 from skimage.morphology import disk
 from skimage.segmentation import flood_fill
 import scipy as sc
 import numpy as np
+import argparse
+def get_parser():
+    parser = argparse.ArgumentParser(
+    description="Close the segmentation of the CSF to get the segmentation of the canal." )
+    parser.add_argument('-i', required = True, type=str,
+                        help="Input segmentation of the CSF.")
+    parser.add_argument('-o', required = True, type=str,
+                        help="Ouput image name.")
+    parser.add_argument('-s', required = True, type=str, 
+                        help="Segmentation of the spinal cord ")
 
-def segmentcanal(csfseg,moelleseg) : 
+    return parser
+
+def main() : 
+    
+    parser = get_parser()
+    args = parser.parse_args()
+
 #Fonction pour sauvegarder fournis par Sandrine
     def save_Nifti1(data, original_image, filename):
         empty_header = nib.Nifti1Header()
@@ -17,45 +33,50 @@ def segmentcanal(csfseg,moelleseg) :
         nib.save(image, filename)
 
 #Je load l'image
-    moelle=nib.load(moelleseg)
-    moelle_np=moelle.get_fdata()
-    img=nib.load(csfseg)
+    moelle = nib.load(args.s)
+    moelle_np = moelle.get_fdata()
+    img = nib.load(args.i)
     img_np = img.get_fdata()
 
-#Je copie l'image pour avoir l'image pour la sauvegarder à la fin
-    img_b=img_np.copy()
-    moelle_b=moelle_np.copy()
+#Je copie l'image pour avoir l'original pour la sauvegarder à la fin
+    img_b = img_np.copy()
+    moelle_b = moelle_np.copy()
 #Image qui sera remplie (besoin pour éviter les floodfill quand ce n'est pas fermé)
-    img_fill=img_b.copy()
+    img_fill = img_b.copy()
 
 #Méthode du floodfill avec le centre de masse
-    imagenbr=img_b.shape[2]#Je prend le nombre de coupe transversale
-    slice=0
-    h,w=img_b[:,:,1].shape
+    imagenbr = img_b.shape[2]#Je prend le nombre de coupe transversale
+    slice = 0
+    h,w = img_b[:, :, 1].shape
 
-    while slice<imagenbr : #J'itère sur les images de coupe
-        cmcsf=(sc.ndimage.center_of_mass(img_b[:,:,slice]))
-        cmmoelle=(sc.ndimage.center_of_mass(moelle_b[:,:,slice]))
+    while slice < imagenbr : #J'itère sur les images de coupe
+        cmcsf = (sc.ndimage.center_of_mass(img_b[:, :, slice]))
+        cmmoelle = (sc.ndimage.center_of_mass(moelle_b[:, :, slice]))
     
-        if np.isnan(cmcsf[0]) and np.isnan(cmcsf[1]) : #Si il n'y as pas de segmentation sur le csf on ne change rien
-            img_fill[:,:,slice]=img_b[:,:,slice] 
+        if (np.isnan(cmcsf[0]) and 
+            np.isnan(cmcsf[1])) : #Si il n'y as pas de segmentation sur le csf on ne change rien
+            img_fill[:, :, slice] = img_b[:, :, slice] 
 
         else : #Si la segmentation n'est pas nulle dans la slice
 
-            if np.isnan(cmmoelle[0]) and np.isnan(cmmoelle[1]) :#Si il n'y as pas de segmentation sur la moelle je ne change rien et je retire la segmentation du csf
-                img_fill[:,:,slice]=0
+            if (np.isnan(cmmoelle[0]) and 
+                np.isnan(cmmoelle[1])) :#Si il n'y as pas de segmentation sur la moelle je ne change rien et je retire la segmentation du csf
+                img_fill[:, :, slice] = 0
 
             else :#Si il y as une segmentation de la moelle et du csf je prend le centre de masse de la moelle 
-                cmmoelle=list(cmmoelle)
-                cmmoelle[0]=int(cmmoelle[0])
-                cmmoelle[1]=int(cmmoelle[1])
-                img_fill[:,:,slice]=flood_fill(img_fill[:,:,slice],(cmmoelle[0],cmmoelle[1]),1)
+                cmmoelle = list(cmmoelle)
+                cmmoelle[0] = int(cmmoelle[0])
+                cmmoelle[1] = int(cmmoelle[1])
+                img_fill[:,:,slice] = flood_fill(img_fill[:,:,slice], (cmmoelle[0],cmmoelle[1]), 1)
 
-                if np.sum(img_fill[:,:,slice]==1)==(h*w): #Si ma forme n'est pas fermée je reprend l'image de base et je fais une fermeture
-                    img_fill[:,:,slice]=cv.morphologyEx(img_b[:,:,slice], cv.MORPH_CLOSE,disk(20))
+                if np.sum(img_fill[:,:,slice] == 1) == (h*w): #Si ma forme n'est pas fermée je reprend l'image de base et je fais une fermeture
+                    img_fill[:, :, slice] = cv.morphologyEx(img_b[:,:,slice], cv.MORPH_CLOSE,disk(20))
             
-        slice=slice+1 #Je passe à la prochaine slice
+        slice = slice+1 #Je passe à la prochaine slice
 
 #Je sauvegarde l'image(Je ne sais pas comment renommer mes images seulement une façon qui ressemble à la votre)
-    Nomdecanal=csfseg.replace("csfseg-manual_RPI_r.nii","canalseg-manual_RPI_r.nii.")
-    save_Nifti1(img_fill,img, Nomdecanal)
+    save_Nifti1(img_fill, img, args.o)
+
+
+if __name__ == '__main__':
+    main() 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+#Liste des librairies à import
+nibabel
+argparse
+opencv-python
+scikit-image

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-#Liste des librairies à import
 nibabel
 argparse
 opencv-python


### PR DESCRIPTION
Fixes #2 
La version utilisée du spine generic dataset est la suivante : r20231212
Le code pour obtenir la segmentation du canal spinal prend en entrée la segmentation du CSF puis remplis la segmentation.
Au début j'utilisait une fermeture sur tout le set d'image, ce qui avait comme effet d'ajouter du bruit en dehors du CSF.
Donc j'ai modifier la méthode de remplissage pour utiliser un remplissage à partir d'un point au centre de la moelle.
**Fonctionnement**
À partir de la segmentation de la moelle, le centre de masse est déterminé pour chaque tranche transversale.
Si il n'y as pas de segmentation du CSF (le CSF n'apparait pas sur l'image), on ne remplace pas l'image.
Si il n'y as pas de segmentation de la moelle, on met l'image à 0.
Si le CSF et la moelle on des segmentations sur la tranche, un floodfill est fait à partir du centre de masse déterminé plus haut.
Le code évalue ensuite si l'image est pleine de 1 (région non fermée lors du floodfill)
Si l'image est pleine de 1, on reprend l'image de base et on fait une fermeture. 
Le fait de faire la fermeture sur certaines images ne semble pas causée d'ajout de bruit à l'extérieur du CSF selon ce que j'ai  observé. 
**Comment tester le code**
Le code prend en entrée trois arguments de la manière suivante : 
~~~
python fill-csf.py -i "Nom du fichier de segmentation du CSF" -o "Nom du fichier de sortie" -s "Nom du fichier contenant la segmentation de la moelle épinière"
~~~
Voici une commande exacte qui permet de tester le code : 
~~~
python fill-csf.py -i "sub-cmrrb03_T2w_csfseg-manual.nii.gz" -o "sub-cmrrb03_T2w_canalseg-manual.nii.gz" -s "sub-cmrrb03_T2w_seg-manual.nii.gz"
~~~

